### PR TITLE
Enable new lambda syntax

### DIFF
--- a/docs/lambdas.md
+++ b/docs/lambdas.md
@@ -1,8 +1,81 @@
 # Lambdas
 
-Lambdas are used to treat functions as first-struct citizens. You can pass lambdas as method parameters.
+Lambdas are used to treat callables (i.e. functions) as first-class citizens. You can pass lambdas as method parameters.
 
-You can define a lambda using the `with` keyword.
+# Table of Contents
+- [Defining and calling lambdas](#defining-and-calling-lambdas)
+  - [Using `do` (lambda block and arrow functions)](#using-do-lambda-block-and-arrow-functions)
+  - [Using the `with` keyword](#using-the-with-keyword)
+  - [Converting a function to a lambda](#)
+- [Inline lambdas](#inline-lambdas)
+- [Assigned lambdas](#assigned-lambdas)
+- [Passing lambdas as parameters](#passing-lambdas-as-parameters)
+
+## Defining and calling lambdas
+
+There are many ways to define a lambda.
+
+### Converting a function to a lambda
+
+You can convert a function to a lambda by calling `to_lambda()` on it.
+
+*Note: Remember you can invoke any callable directly or by calling `.call([parameters])` on it.*
+
+```kiwi
+fn say_hello(name: string)
+  println "Hello, ${name}!"
+end
+
+fn say_bye(name: string)
+  println "Bye, ${name}!"
+end
+
+fn get_strategy(strategy: string)
+  if strategy == "hello"
+    return say_hello.to_lambda()
+  elsif strategy == "bye"
+    return say_bye.to_lambda()
+  else
+    throw "Unknown strategy"
+  end
+end
+
+fn use_strategy(strategy: string, name: string)
+  get_strategy(strategy).call([name])
+end
+
+use_strategy("hello", "World")
+use_strategy("bye", "World")
+```
+
+### Using `do` (lambda block and arrow functions)
+
+For simple one liners, you might use an arrow function.
+```kiwi
+println [1 to 10].filter(do (n) => n % 2 == 0)
+# [2, 4, 6, 8, 10]
+```
+
+Or for more complex requirements, you can implement within a block. 
+
+*Note: Remember, the last evaluation of the callable is its return value!*
+```kiwi
+println [1 to 10].filter(do (n)
+    n % 2 != 0
+end)
+# [1, 3, 5, 7, 9]
+```
+
+Some more examples:
+```kiwi
+# An assigned lambda
+say_hello = do (name: string) => println "Hello, ${name}!"
+
+# Direct invocation of closure
+(do (name: string) => println "Hello, ${name}!")("World!")
+```
+
+### Using the `with` keyword
 
 For demonstration, we will define a list of hashmaps called `id_list` to be used in the examples below.
 
@@ -14,36 +87,32 @@ id_list = [
 ]
 ```
 
-### Inline Lambdas
+## Inline lambdas
 
 Lambdas can be used inline (without assignment).
 
 ```kiwi
-println(id_list.filter(with (item) do return item["id"] % 2 == 0 end))
+println(id_list.filter(do (item) => item["id"] % 2 == 0))
 # prints: [{"id": 0}, {"id": 2}, {"id": 4}, {"id": 6}, {"id": 8}]
 ```
 
-### Assigned Lambdas
+## Assigned lambdas
 
 You can assign a reference to a lambda for reuse.
 
 ```kiwi
-odd_item_id = with (item) do
-  return item["id"] % 2 != 0
-end
+odd_item_id = do (item) => item["id"] % 2 != 0
 
 println(id_list.filter(odd_item_id))
 # prints: [{"id": 1}, {"id": 3}, {"id": 5}, {"id": 7}, {"id": 9}]
 ```
 
-### Passing Lambdas as Parameters
+## Passing lambdas as parameters
 
 You can pass lambdas as parameters to methods.
 
 ```kiwi
-puts = with (s) do
-  println(s)
-end
+puts = do (s) => println(s)
 
 puts("Hello, World!") # prints: Hello, World!
 

--- a/src/Parsing/Lexer.cs
+++ b/src/Parsing/Lexer.cs
@@ -516,6 +516,7 @@ public class Lexer : IDisposable
 
             // 2-char
             "=<" => TokenName.Ops_Unpack,
+            "=>" => TokenName.Arrow,
             "+=" => TokenName.Ops_AddAssign,
             "-=" => TokenName.Ops_SubtractAssign,
             "*=" => TokenName.Ops_MultiplyAssign,
@@ -564,6 +565,11 @@ public class Lexer : IDisposable
         {
             // ternary
             return CreateToken(TokenType.Question, span, "?");
+        }
+        else if (name == TokenName.Arrow)
+        {
+            // =>
+            return CreateToken(TokenType.Arrow, span, "=>");
         }
 
         return CreateToken(TokenType.Operator, span, text, name);

--- a/src/Parsing/Name.cs
+++ b/src/Parsing/Name.cs
@@ -3,6 +3,7 @@ namespace kiwi.Parsing;
 public enum TokenName
 {
   Default,
+  Arrow,
   Builtin_Callable_Call,
   Builtin_Callable_Parameters,
   Builtin_Callable_Returns,

--- a/src/Parsing/Token.cs
+++ b/src/Parsing/Token.cs
@@ -154,6 +154,7 @@ public enum TokenType
     Typename,
     Lambda,
     Question,
+    Arrow,
     Error,
     Eof
 }


### PR DESCRIPTION
This side quest closes Concise Lambda Expressions #308

```kiwi
# do-block lambda
println [1 to 10].filter(do (n)
    n % 2 != 0
end)
# [1, 3, 5, 7, 9]

# do-arrow functions
say_hello = do (name: string) => println "Hello, ${name}!"

(do (name: string) => println "Hello, ${name}!")("World!")
```

The old syntax still works.