### PR TITLE
feat: make include an expression returning the declared package value

### DIFF
--- a/src/Parsing/AST/IncludeNode.cs
+++ b/src/Parsing/AST/IncludeNode.cs
@@ -1,6 +1,6 @@
 namespace kiwi.Parsing.AST;
 
-public class IncludeNode(ASTNode path) : ASTNode(ASTNodeType.Include)
+public class IncludeNode(ASTNode path) : ASTNode(ASTNodeType.Include) // expression yields package
 {
     public ASTNode Path { get; } = path;
 

--- a/src/VM/Compiler.cs
+++ b/src/VM/Compiler.cs
@@ -473,7 +473,7 @@ public sealed class Compiler
             case ASTNodeType.Import:           CompileImport         ((ImportNode)node,            ln); return true;
             case ASTNodeType.Require:          CompileRequire        ((RequireNode)node,           ln); return false;
             case ASTNodeType.Eval:             CompileEval           ((EvalNode)node,              ln); return true;
-            case ASTNodeType.Include:          CompileInclude        ((IncludeNode)node,           ln); return false;
+            case ASTNodeType.Include:          CompileInclude        ((IncludeNode)node,           ln); return true;
             case ASTNodeType.Enum:             CompileEnum           ((EnumNode)node,              ln); return false;
             case ASTNodeType.DecoratedFunction: CompileDecoratedFunction((DecoratedFunctionNode)node, ln); return false;
             case ASTNodeType.Lambda:           CompileLambdaDef      ((LambdaNode)node,            ln); return true;
@@ -1761,7 +1761,7 @@ foreach (var j in ctx.BreakPatches) PatchJumpTo(j, done);
     private void CompileInclude(IncludeNode node, int ln)
     {
         CompileNode(node.Path);
-        Emit(Opcode.Include, 0, 0, ln);
+        Emit(Opcode.Include, 0, 0, ln); // now leaves package Value on stack
     }
 
     // -- Enum definition -------------------------------------------------------

--- a/src/VM/KiwiVM.cs
+++ b/src/VM/KiwiVM.cs
@@ -1698,7 +1698,8 @@ public sealed class KiwiVM
                         var path = Pop();
                         if (!path.IsString())
                             throw new InvalidOperationError(frame.GetToken(), "Include path must be a string.");
-                        IncludeFile(frame.GetToken(), path.GetString());
+                        var pkg = IncludeFile(frame.GetToken(), path.GetString());
+                        Push(pkg);
                         break;
                     }
 
@@ -2526,8 +2527,14 @@ public sealed class KiwiVM
         {
             using var lexer = new Lexer(fullPath);
             var ast   = new Parser(true).ParseTokenStream(lexer.GetTokenStream(), true);
-            var chunk = Compiler.CompileProgram((ProgramNode)ast);
+            var prog = (ProgramNode)ast;
+            var pkgNode = prog.Statements.OfType<PackageNode>().FirstOrDefault();
+            string pkgName = "";
+            if (pkgNode?.PackageName is IdentifierNode id) pkgName = id.Name;
+            else if (pkgNode?.PackageName is LiteralNode lit && lit.Value.IsString()) pkgName = lit.Value.GetString();
+            var chunk = Compiler.CompileProgram(prog);
             new KiwiVM(this).Execute(chunk);
+            return string.IsNullOrEmpty(pkgName) ? Value.Default : Value.CreatePackage(pkgName);
         }
         finally
         {


### PR DESCRIPTION
This is the cleanest run of the brownfield-graph [fuseraft-cli](https://github.com/fuseraft/fuseraft-cli) config to date. 

<pre><font color="#4E9A06">scs@fedora </font><font color="#3465A4">~/github/kiwi-lang/kiwi</font>
<font color="#06989A">$ </font>fuseraft run -c .fuseraft/config/orchestration.yaml -f /tmp/fuseraft-task-1779337089802-s4lx4hxvv2.txt 

<font color="#34E2E2"> .|&apos;;                                       .|&apos;;   ||    </font>
<font color="#34E2E2"> ||                                         ||     ||    </font>
<font color="#34E2E2">&apos;||&apos;  &apos;||  ||` (&apos;&apos;&apos;&apos; .|&apos;&apos;|, &apos;||&apos;&apos;|  &apos;&apos;&apos;|.  &apos;||&apos;  &apos;&apos;||&apos;&apos;  </font>
<font color="#34E2E2"> ||    ||  ||   `&apos;&apos;) ||..||  ||    .|&apos;&apos;||   ||     ||    </font>
<font color="#34E2E2">.||.   `|..&apos;|. `...&apos; `|...  .||.   `|..||. .||.    `|..&apos; </font>
<font color="#34E2E2">                                                         </font>
<font color="#34E2E2">                                                         </font>
<font color="#AAAAAA">Multi-Agent Orchestration · Powered by Microsoft Agent Framework</font>

<font color="#AAAAAA">Working directory → /home/scs/github/kiwi-lang/kiwi</font>
                           <font color="#D3D7CF"><b>Brownfield Graph Pipeline</b></font>                            
<font color="#555753">╭───────────────┬─────────────────────────────┬────────────────────────────────╮</font>
<font color="#555753">│</font> <b>Agent</b>         <font color="#555753">│</font> <b>Model</b>                       <font color="#555753">│</font> <b>Plugins</b>                        <font color="#555753">│</font>
<font color="#555753">├───────────────┼─────────────────────────────┼────────────────────────────────┤</font>
<font color="#555753">│</font> <font color="#34E2E2">Archaeologist</font> <font color="#555753">│</font> grok-4-1-fast               <font color="#555753">│</font> FileSystem, Search, SubAgent,  <font color="#555753">│</font>
<font color="#555753">│</font>               <font color="#555753">│</font>                             <font color="#555753">│</font> Handoff                        <font color="#555753">│</font>
<font color="#555753">│</font> <font color="#FCE94F">Planner</font>       <font color="#555753">│</font> grok-4-1-fast-reasoning     <font color="#555753">│</font> FileSystem, Search, SubAgent,  <font color="#555753">│</font>
<font color="#555753">│</font>               <font color="#555753">│</font>                             <font color="#555753">│</font> Handoff                        <font color="#555753">│</font>
<font color="#555753">│</font> <font color="#AD7FA8">Developer</font>     <font color="#555753">│</font> grok-4-1-fast               <font color="#555753">│</font> FileSystem, Shell, Git,        <font color="#555753">│</font>
<font color="#555753">│</font>               <font color="#555753">│</font>                             <font color="#555753">│</font> Changes, Handoff               <font color="#555753">│</font>
<font color="#555753">│</font> <font color="#4E9A06">Reviewer</font>      <font color="#555753">│</font> grok-4-1-fast-reasoning     <font color="#555753">│</font> FileSystem, Shell, Changes,    <font color="#555753">│</font>
<font color="#555753">│</font>               <font color="#555753">│</font>                             <font color="#555753">│</font> Handoff                        <font color="#555753">│</font>
<font color="#555753">│</font> <font color="#FFAF00">Approved</font>      <font color="#555753">│</font> grok-4-1-fast-non-reasoning <font color="#555753">│</font> none                           <font color="#555753">│</font>
<font color="#555753">╰───────────────┴─────────────────────────────┴────────────────────────────────╯</font>
<font color="#AAAAAA">Selection: graph  Termination: composite/2 rules, max=0</font>

<font color="#AAAAAA"><b>┏━Task━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>See AGENTS.md to learn how to work on kiwi.</b>                                  <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font>                                                                              <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>Implement this new syntax:</b>                                                   <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font>                                                                              <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>**app.kiwi**:</b>                                                                <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>```kiwi</b>                                                                      <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>x = include &apos;mylib/libfoo&apos;</b>                                                   <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>x.foofunc() # prints: funky foo!</b>                                             <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>```</b>                                                                          <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font>                                                                              <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>**mylib/libfoo.kiwi**:</b>                                                       <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>```kiwi</b>                                                                      <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>package foo</b>                                                                  <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>  fn foofunc()</b>                                                               <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>    println &quot;funky foo!&quot;</b>                                                     <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>  end</b>                                                                        <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>end</b>                                                                          <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>```</b>                                                                          <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font>                                                                              <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>The include statement should also be an expression that we can assign to a </b>  <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>variable (`x` in our example above). Calling `x.foofunc()` calls the package</b> <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┃</b></font> <b>`foo`&apos;s `foofunc` function.</b>                                                  <font color="#AAAAAA"><b>┃</b></font>
<font color="#AAAAAA"><b>┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛</b></font>

<font color="#34E2E2">╭─</font><font color="#34E2E2"><b>Archaeologist</b></font><font color="#34E2E2">  turn 1  29.2s  in:39,727 out:472──────────────────────────────╮</font>
<font color="#34E2E2">│</font> (7 tool calls — run with --tools to see details)                             <font color="#34E2E2">│</font>
<font color="#34E2E2">╰──────────────────────────────────────────────────────────────────────────────╯</font>
                                                                                
<font color="#FCE94F">╭─</font><font color="#FCE94F"><b>Planner</b></font><font color="#FCE94F">  turn 2  34.8s  in:45,299 out:359────────────────────────────────────╮</font>
<font color="#FCE94F">│</font> (4 tool calls — run with --tools to see details)                             <font color="#FCE94F">│</font>
<font color="#FCE94F">╰──────────────────────────────────────────────────────────────────────────────╯</font>
                                                                                
<font color="#FCE94F">  ⚠ Developer used 494,342 input tokens this turn (warning threshold: 300,000). </font>
<font color="#FCE94F">Reduce file reads and shell output to avoid a budget blowup.</font><font color="#AAAAAA">ssion returning the </font>
<font color="#AD7FA8">╭─</font><font color="#AD7FA8"><b>Developer</b></font><font color="#AD7FA8">  turn 3  120.5s  in:494,342 out:1,777──────────────────────────────╮</font>
<font color="#AD7FA8">│</font> (30 tool calls — run with --tools to see details)                            <font color="#AD7FA8">│</font>
<font color="#AD7FA8">╰──────────────────────────────────────────────────────────────────────────────╯</font>
                                                                                
<font color="#4E9A06">╭─</font><font color="#4E9A06"><b>Reviewer</b></font><font color="#4E9A06">  turn 4  42.3s  in:68,224 out:527───────────────────────────────────╮</font>
<font color="#4E9A06">│</font> {   &quot;review&quot;: [     {&quot;criterion&quot;: &quot;include expr compiles without new opcode  <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> or reuses Include to leave Package on stack&quot;, &quot;verdict&quot;: &quot;PASS&quot;, &quot;evidence&quot;: <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &quot;Compiler.cs:1763-1764 reuses Emit(Opcode.Include); KiwiVM.cs:1701-1702      <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> calls IncludeFile then Push(pkg)&quot;},     {&quot;criterion&quot;: &quot;x = include           <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &apos;mylib/libfoo&apos; succeeds and x.foofunc() invokes the fn from package foo&quot;,    <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &quot;verdict&quot;: &quot;PASS&quot;, &quot;evidence&quot;: &quot;Developer run of tmp/app.kiwi produced       <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &apos;funky foo!&apos; output&quot;},     {&quot;criterion&quot;: &quot;existing require/import/include    <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> semantics unchanged for non-assignment uses&quot;, &quot;verdict&quot;: &quot;PASS&quot;, &quot;evidence&quot;: <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &quot;tests/test.kiwi packages test + all 82 tests passed&quot;},     {&quot;criterion&quot;:    <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &quot;full test suite passes after rebuild&quot;, &quot;verdict&quot;: &quot;PASS&quot;, &quot;evidence&quot;:       <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &quot;./build.sh OK; ./bin/kiwi tests/test.kiwi: 82/82 PASSED&quot;},                  <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> {&quot;criterion&quot;: &quot;no files outside files_to_change modified&quot;, &quot;verdict&quot;:        <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> &quot;PASS&quot;, &quot;evidence&quot;: &quot;changes_read_latest shows only                          <font color="#4E9A06">│</font>
<font color="#4E9A06">│</font> src/VM/{Compiler,KiwiVM}.cs + IncludeNode.cs + briefs&quot;}   ] } APPROVED       <font color="#4E9A06">│</font>
<font color="#4E9A06">╰──────────────────────────────────────────────────────────────────────────────╯</font>
                                                                                
<font color="#FFAF00">╭─</font><font color="#FFAF00"><b>Approved</b></font><font color="#FFAF00">  turn 5  1.2s  in:24,346 out:3──────────────────────────────────────╮</font>
<font color="#FFAF00">│</font> Task complete.                                                               <font color="#FFAF00">│</font>
<font color="#FFAF00">╰──────────────────────────────────────────────────────────────────────────────╯</font>
                                                                                
<font color="#AAAAAA">Context viz → .fuseraft/logs/ctx_viz_12226d6a.html</font>
<font color="#AAAAAA">─────────────────────────────── </font><font color="#AAAAAA"><b>Session Summary</b></font><font color="#AAAAAA"> ────────────────────────────────</font>

<font color="#555753">                                                        </font>
<font color="#555753"> </font> <b>Agent</b>         <font color="#555753"> </font> <b>Turns</b> <font color="#555753"> </font> <b>Input tokens</b> <font color="#555753"> </font> <b>Output tokens</b> <font color="#555753"> </font>
<font color="#555753">────────────────────────────────────────────────────────</font>
<font color="#555753"> </font> <font color="#34E2E2">Archaeologist</font> <font color="#555753"> </font>     1 <font color="#555753"> </font>       39,727 <font color="#555753"> </font>           472 <font color="#555753"> </font>
<font color="#555753"> </font> <font color="#FCE94F">Planner</font>       <font color="#555753"> </font>     1 <font color="#555753"> </font>       45,299 <font color="#555753"> </font>           359 <font color="#555753"> </font>
<font color="#555753"> </font> <font color="#AD7FA8">Developer</font>     <font color="#555753"> </font>     1 <font color="#555753"> </font>      494,342 <font color="#555753"> </font>         1,777 <font color="#555753"> </font>
<font color="#555753"> </font> <font color="#4E9A06">Reviewer</font>      <font color="#555753"> </font>     1 <font color="#555753"> </font>       68,224 <font color="#555753"> </font>           527 <font color="#555753"> </font>
<font color="#555753"> </font> <font color="#FFAF00">Approved</font>      <font color="#555753"> </font>     1 <font color="#555753"> </font>       24,346 <font color="#555753"> </font>             3 <font color="#555753"> </font>
<font color="#555753"> </font>               <font color="#555753"> </font>       <font color="#555753"> </font>              <font color="#555753"> </font>               <font color="#555753"> </font>
<font color="#555753"> </font> <b>Total</b>         <font color="#555753"> </font>     <b>5</b> <font color="#555753"> </font>      <b>671,938</b> <font color="#555753"> </font>         <b>3,138</b> <font color="#555753"> </font>
<font color="#555753">                                                        </font>

<font color="#4E9A06">✓ Completed</font>  in 3.8 min

<font color="#4E9A06">Policy compliance:</font> <b>100.0%</b>  0 error budget remaining
</pre>